### PR TITLE
fix(adguardhome): restrict outbound traffic

### DIFF
--- a/kubernetes/main/apps/adguardhome/deployment.yaml
+++ b/kubernetes/main/apps/adguardhome/deployment.yaml
@@ -27,9 +27,6 @@ spec:
         - name: users
           secret:
             secretName: users
-        - name: adguardhome-sync
-          secret:
-            secretName: adguardhome-sync
         - name: config-folder
           emptyDir: {}
         - name: work-folder

--- a/kubernetes/main/apps/adguardhome/network-policies.yaml
+++ b/kubernetes/main/apps/adguardhome/network-policies.yaml
@@ -10,6 +10,17 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: default-deny-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: adguardhome
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: allow-from-cilium-gateway
 spec:
   podSelector:
@@ -42,3 +53,22 @@ spec:
           port: 853
         - protocol: UDP
           port: 853
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-upstream-dns-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: adguardhome
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
- removed the unused \ secret volume from the AdGuard Home deployment
- added a default-deny egress network policy for the AdGuard Home pod
- added an explicit egress allow policy for outbound DNS on port 53 TCP/UDP and HTTPS on 443