### PR TITLE
Fix cluster storage rollouts and migrate CNPG backups to plugin

### DIFF
--- a/kubernetes/main/apps/freshrss/database.yaml
+++ b/kubernetes/main/apps/freshrss/database.yaml
@@ -26,26 +26,12 @@ spec:
 
   logLevel: info
 
-  backup:
-    barmanObjectStore:
-      destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
-      endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
-      serverName: freshrss-database-v2
-      s3Credentials:
-        accessKeyId:
-          name: freshrss
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: freshrss
-          key: SECRET_ACCESS_KEY
-      data:
-        compression: bzip2
-        encryption: AES256
-      wal:
-        compression: bzip2
-        maxParallel: 4
-        encryption: AES256
-    retentionPolicy: "7d"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: freshrss-database
+        serverName: freshrss-database-v2
 
   primaryUpdateStrategy: unsupervised
 
@@ -77,14 +63,30 @@ spec:
     limits:
       memory: "768Mi"
 ---
-apiVersion: postgresql.cnpg.io/v1
-kind: Backup
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
 metadata:
-  name: freshrss
+  name: freshrss-database
   namespace: freshrss
 spec:
-  cluster:
-    name: freshrss-database
+  configuration:
+    destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
+    endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
+    s3Credentials:
+      accessKeyId:
+        name: freshrss
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: freshrss
+        key: SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+      encryption: AES256
+    wal:
+      compression: bzip2
+      maxParallel: 4
+      encryption: AES256
+  retentionPolicy: "7d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -96,3 +98,6 @@ spec:
   backupOwnerReference: self
   cluster:
     name: freshrss-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/main/apps/freshrss/deployment.yaml
+++ b/kubernetes/main/apps/freshrss/deployment.yaml
@@ -5,10 +5,8 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: freshrss

--- a/kubernetes/main/apps/monitoring/victoria-metrics-k8s-stack/database.yaml
+++ b/kubernetes/main/apps/monitoring/victoria-metrics-k8s-stack/database.yaml
@@ -21,26 +21,12 @@ spec:
       checkpoint_completion_target: "0.9"
       wal_keep_size: "128MB"
 
-  backup:
-    barmanObjectStore:
-      destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
-      endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
-      serverName: grafana-database-v3
-      s3Credentials:
-        accessKeyId:
-          name: victoriametricsstack-oauth2
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: victoriametricsstack-oauth2
-          key: SECRET_ACCESS_KEY
-      data:
-        compression: bzip2
-        encryption: AES256
-      wal:
-        compression: bzip2
-        maxParallel: 4
-        encryption: AES256
-    retentionPolicy: "3d"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: grafana-database
+        serverName: grafana-database-v3
 
   logLevel: info
   primaryUpdateStrategy: unsupervised
@@ -73,14 +59,30 @@ spec:
     limits:
       memory: "384Mi"
 ---
-apiVersion: postgresql.cnpg.io/v1
-kind: Backup
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
 metadata:
-  name: grafana
+  name: grafana-database
   namespace: kube-monitoring
 spec:
-  cluster:
-    name: grafana-database
+  configuration:
+    destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
+    endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
+    s3Credentials:
+      accessKeyId:
+        name: victoriametricsstack-oauth2
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: victoriametricsstack-oauth2
+        key: SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+      encryption: AES256
+    wal:
+      compression: bzip2
+      maxParallel: 4
+      encryption: AES256
+  retentionPolicy: "3d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -92,3 +94,6 @@ spec:
   backupOwnerReference: self
   cluster:
     name: grafana-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/main/apps/n8n/database.yaml
+++ b/kubernetes/main/apps/n8n/database.yaml
@@ -24,26 +24,12 @@ spec:
       database: n8n
       owner: n8n
 
-  backup:
-    barmanObjectStore:
-      destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
-      endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
-      serverName: n8n-database-v1
-      s3Credentials:
-        accessKeyId:
-          name: n8n
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: n8n
-          key: SECRET_ACCESS_KEY
-      data:
-        compression: bzip2
-        encryption: AES256
-      wal:
-        compression: bzip2
-        maxParallel: 4
-        encryption: AES256
-    retentionPolicy: "7d"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: n8n-database
+        serverName: n8n-database-v1
 
   logLevel: info
   primaryUpdateStrategy: unsupervised
@@ -63,7 +49,7 @@ spec:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 1Gi
+          storage: 4Gi
       storageClassName: proxmox-k8s-lvm
 
   monitoring:
@@ -76,14 +62,30 @@ spec:
     limits:
       memory: "768Mi"
 ---
-apiVersion: postgresql.cnpg.io/v1
-kind: Backup
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
 metadata:
-  name: n8n
+  name: n8n-database
   namespace: n8n
 spec:
-  cluster:
-    name: n8n-database
+  configuration:
+    destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
+    endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
+    s3Credentials:
+      accessKeyId:
+        name: n8n
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: n8n
+        key: SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+      encryption: AES256
+    wal:
+      compression: bzip2
+      maxParallel: 4
+      encryption: AES256
+  retentionPolicy: "7d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -95,3 +97,6 @@ spec:
   backupOwnerReference: self
   cluster:
     name: n8n-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/main/apps/teslamate/database.yaml
+++ b/kubernetes/main/apps/teslamate/database.yaml
@@ -19,26 +19,12 @@ spec:
       checkpoint_completion_target: "0.9"
       wal_keep_size: "256MB"
 
-  backup:
-    barmanObjectStore:
-      destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
-      endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
-      serverName: teslamate-database-v2
-      s3Credentials:
-        accessKeyId:
-          name: teslamate
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: teslamate
-          key: SECRET_ACCESS_KEY
-      data:
-        compression: bzip2
-        encryption: AES256
-      wal:
-        compression: bzip2
-        maxParallel: 4
-        encryption: AES256
-    retentionPolicy: "7d"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: teslamate-database
+        serverName: teslamate-database-v2
 
   enableSuperuserAccess: true
   superuserSecret:
@@ -75,15 +61,30 @@ spec:
       memory: "768Mi"
 
 ---
-apiVersion: postgresql.cnpg.io/v1
-kind: Backup
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
 metadata:
-  name: teslamate
+  name: teslamate-database
   namespace: teslamate
 spec:
-  cluster:
-    name: teslamate-database
-
+  configuration:
+    destinationPath: s3://nidr0x-homelab-backups/cloudnative-pg
+    endpointURL: https://de6356c843cfe00a0c3ff3b669892ca9.r2.cloudflarestorage.com
+    s3Credentials:
+      accessKeyId:
+        name: teslamate
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: teslamate
+        key: SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+      encryption: AES256
+    wal:
+      compression: bzip2
+      maxParallel: 4
+      encryption: AES256
+  retentionPolicy: "7d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -95,3 +96,6 @@ spec:
   backupOwnerReference: self
   cluster:
     name: teslamate-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/main/apps/wallos/deployment.yaml
+++ b/kubernetes/main/apps/wallos/deployment.yaml
@@ -5,10 +5,8 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: wallos


### PR DESCRIPTION
- Migrate the n8n, FreshRSS, Teslamate, and Grafana CloudNativePG clusters from native barmanObjectStore backup configuration to the Barman Cloud plugin.

- Add plugin-backed ObjectStore resources, switch scheduled backups to plugin mode, and preserve the existing archive paths for each cluster.
 
- Increase n8n WAL storage to 4Gi and switch the single-replica FreshRSS and Wallos deployments to Recreate so RWO-backed rollouts do not deadlock.