### PR TITLE
fix: add victoria logs path prefix to grafana datasource

### DIFF
--- a/kubernetes/main/apps/monitoring/victoria-metrics-k8s-stack/values.yaml
+++ b/kubernetes/main/apps/monitoring/victoria-metrics-k8s-stack/values.yaml
@@ -17,7 +17,7 @@ defaultDatasources:
       isDefault: false
     - name: VictoriaLogs
       type: victoriametrics-logs-datasource
-      url: http://victorialogs-server.kube-monitoring.svc.cluster.local:9428
+      url: http://victorialogs-server.kube-monitoring.svc.cluster.local:9428/victorialogs
       access: proxy
       jsonData:
         maxLines: 1000


### PR DESCRIPTION
Fix the Victoria Logs Grafana datasource URL to include the required /victorialogs path prefix so log queries stop failing with the missing -http.pathPrefix error.